### PR TITLE
Add reference to W3C WoT TD 1.1. Recommendation

### DIFF
--- a/draft-bormann-asdf-sdf-mapping.md
+++ b/draft-bormann-asdf-sdf-mapping.md
@@ -45,6 +45,7 @@ normative:
   I-D.ietf-asdf-sdf: sdf
 informative:
   RFC8576: seccons
+  W3C.wot-thing-description11: wot-td
 
 entity:
         SELF: "[RFC-XXXX]"
@@ -150,6 +151,7 @@ by OneDM, and to add qualities relevant to the IPSO/OMA ecosystem.
 ## Example Model 2 (ecosystem: W3C WoT) {#example2}
 
 This example shows a translation of a hypothetical W3C WoT Thing Model
+(as defined in Section 10 of {{-wot-td}})
 into an SDF model plus a mapping file to catch Thing Model attributes
 that don't currently have SDF qualities defined.
 [^td-note]


### PR DESCRIPTION
This PR adds a reference to the WoT TD 1.1 Recommendation in the section on WoT Thing Models.