### PR TITLE
Start improving the document structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ else
 endif
 endif
 
-sourcecode: draft-bormann-asdf-sdf-mapping.xml
+sourcecode: draft-ietf-asdf-sdf-mapping.xml
 	kramdown-rfc-extract-sourcecode -tfiles $^
 
 sdfcheck: sourcecode
 	for file in sourcecode/sdf/*.sdf; do echo $$file; cddl sdf-feature.cddl vp $$file; done
 
-lists.md: draft-bormann-asdf-sdf-mapping.xml
+lists.md: draft-ietf-asdf-sdf-mapping.xml
 	kramdown-rfc-extract-figures-tables -trfc $< >$@.new
 	if cmp $@.new $@; then rm -v $@.new; else mv -v $@.new $@; fi

--- a/draft-ietf-asdf-sdf-mapping.md
+++ b/draft-ietf-asdf-sdf-mapping.md
@@ -280,8 +280,8 @@ the following steps:
 info:
   title: Augmented SDF model with augmentation log.
   augmentationLog:
-    - https://example.org/sdf-mapping-file-1
-    - https://example.org/sdf-mapping-file-2
+    - https://example.org/sdf-supplement-1
+    - https://example.org/sdf-supplement-2
   originalSdfModel: https://example.org/original-sdf-model
 # TODO: Do we need more information here?
 ~~~
@@ -289,8 +289,8 @@ info:
 
 [^logging]: A convention for "logging" the augmentation steps that
     went into an augmented model needs to be further fleshed out.
-    (An array in the info block that receives additions from a mapping
-    file using the "`‑`" pointer syntax may be a good receptacle for
+    (An array in the info block that receives additions from a supplement
+    using the "`‑`" pointer syntax may be a good receptacle for
     receiving information about multiple augmentations.)
 
 # Ecosystem-specific Examples
@@ -449,9 +449,9 @@ Media Type
 
 IANA is requested to add the following Media-Type to the "Media Types" registry.
 
-| Name             | Template                     | Reference             |
-|------------------|------------------------------|-----------------------|
-| sdf-mapping+json | application/sdf-supplement+json | RFC XXXX, {{media-type}} |
+| Name                | Template                        | Reference                |
+|---------------------|---------------------------------|--------------------------|
+| sdf-supplement+json | application/sdf-supplement+json | RFC XXXX, {{media-type}} |
 {: #new-media-types title="A media type for SDF Supplements" align="left"}
 
 [^to-be-removed]
@@ -463,7 +463,7 @@ Type name:
 : application
 
 Subtype name:
-: sdf-mapping+json
+: sdf-supplement+json
 
 Required parameters:
 : none

--- a/draft-ietf-asdf-sdf-mapping.md
+++ b/draft-ietf-asdf-sdf-mapping.md
@@ -116,32 +116,51 @@ augmenter to the augmented).
 
 The order of the application of patches is that of the elements within the array (which is deterministic in contrast to the order of entries of an object).
 
-# Formal Syntax of SDF Supplements {#syntax}
+# Data Model of SDF Supplements {#data-model}
 
-An SDF Supplement has three optional components that are taken
-unchanged from SDF: The info block, the namespace declaration, and the
-default namespace.
-The mandatory fourth component, the `amend` block, contains the list of amendments that are supposed to be applied to the target model,
-using an SDF name reference (usually a namespace and a JSON pointer) as the target to which a specified quality is applied to.
+<!-- TODO: This text is currently  -->
 
-{{mapping-cddl}} describes the syntax of SDF Supplements using CDDL {{-cddl}}.
+The data model of SDF Supplements makes use of some of the structural features of SDF models (namely the `info` and namespaces blocks), but complements them with a mandatory third Amendments block.
 
-~~~ cddl
-{::include mapping.cddl}
-~~~
-{: #mapping-cddl title="CDDL definition of SDF Supplements"}
+## Information Block
 
-The JSON pointer that is used a the `target` can
-point to a JSON map in the SDF model to be augmented by adding or
-replacing map entries.
-If necessary, the JSON map is created at the position indicated with
-the contents of the `patch` [^example].
-Alternatively, the JSON pointer can point to an array (also possibly
-created if not existing before) and add an element to that array by
-using the "`‑`" syntax introduced in the penultimate paragraph of
-{{Section 4 of -pointer}}.
+A Supplements's information block may contain exactly the same qualities as an SDF model.
 
-[^example]: (add examples)
+| Quality     | Type             | Description                                                 |
+| ----------- | ---------------- | ----------------------------------------------------------- |
+| title       | string           | A short summary to be displayed in search results, etc.     |
+| description | string           | Long-form text description (no constraints)                 |
+| version     | string           | The incremental version of the definition                   |
+| copyright   | string           | Link to text or embedded text containing a copyright notice |
+| license     | string           | Link to text or embedded text containing license terms      |
+| modified    | string           | Time of the latest modification                             |
+| features    | array of strings | List of extension features used                             |
+| $comment    | string           | Source code comments only, no semantics                     |
+{: #infoblockqual title="Qualities of the Information Block"}
+
+## Namespaces Block
+
+The `namespace` and `defaultNamespaces` qualities are also taken over unchanged from base SDF.
+
+| Quality          | Type   | Description                                                                                          |
+| ---------------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| namespace        | map    | Defines short names mapped to namespace URIs, to be used as identifier prefixes                      |
+| defaultNamespace | string | Identifies one of the prefixes in the namespace map to be used as a default in resolving identifiers |
+{: #nssec title="Qualities of the Namespaces Block"}
+
+## Amendments Block
+
+The mandatory third component, the Amendments block, contains the set of patches that are supposed to be applied to the target model,
+Under the `amend` quality, the block consists of an array of JSON maps, whose keys indicate the target for the JSON Merge Patch algorithm {{-merge-patch}}.
+
+| Quality | Type          | Description                                                                                    |
+| ------- | ------------- | ---------------------------------------------------------------------------------------------- |
+| amend   | array of maps | Defines the list of amendments as an array of JSON maps, whose keys indicate the patch target. |
+{: #amendssec title="Qualities of the Amendments Block"}
+
+The JSON pointers can point to a JSON map in the SDF model to be augmented by adding or replacing map entries.
+If necessary, a new JSON map is created at the indicated position.
+Alternatively, the JSON pointer can point to an array (also possibly created if not existing before) and append an element by using the "`‑`" syntax introduced in the penultimate paragraph of {{Section 4 of -pointer}}.
 
 # Augmentation Mechanism
 
@@ -505,6 +524,13 @@ Some wider issues are discussed in {{-seccons}}.
 
 
 --- back
+
+# Formal Syntax of SDF Supplements {#syntax}
+
+~~~ cddl
+{::include mapping.cddl}
+~~~
+{: #mapping-cddl title="CDDL definition of SDF Supplements"}
 
 {::include-all lists.md}
 

--- a/draft-ietf-asdf-sdf-mapping.md
+++ b/draft-ietf-asdf-sdf-mapping.md
@@ -116,149 +116,6 @@ augmenter to the augmented).
 
 The order of the application of patches is that of the elements within the array (which is deterministic in contrast to the order of entries of an object).
 
-## Example Model 1 (ecosystem: IPSO/OMA) {#example1}
-
-An example for an SDF Supplement is given in {{code-example1}}.
-This Supplement is meant to attach to an SDF specification published
-by OneDM, and to add qualities relevant to the IPSO/OMA ecosystem.
-[^namespace-note]
-
-[^namespace-note]: \\
-    Note that this example uses namespaces to identify elements of the
-    referenced specification(s), but has un-namespaced quality names.
-    These two kinds of namespaces are unrelated in SDF, and a more
-    robust example may need to make use of Quality Name Prefixes
-    as defined in {{Section 2.3.3-3 of -sdf}} (independent of a potential
-    feature to add namespace references to definitions that are not
-    intended to go into the default namespace — these are SDF
-    definition namespaces and not quality namespaces, which are one
-    meta-level higher).
-
-* Start of a Supplement for certain OneDM playground models:
-
-~~~ sdf
-info:
-  title: IPSO ID mapping
-namespace:
-  onedm: https://onedm.org/models
-defaultNamespace: onedm
-amend:
-  - "#/sdfObject/Digital_Input":
-      id: 3200
-  - "#/sdfObject/Digital_Input/sdfProperty/Digital_Input_State":
-      id: 5500
-  - "#/sdfObject/Digital_Input/sdfProperty/Digital_Input_Counter":
-      id: 5501
-~~~
-{: #code-example1 check="json" pre="yaml2json" title="A simple example of an SDF Supplement"}
-
-## Example Model 2 (ecosystem: W3C WoT) {#example2}
-
-This example shows a translation of a hypothetical W3C WoT Thing Model
-(as defined in Section 10 of {{-wot-td}})
-into an SDF model plus a Supplement to catch Thing Model attributes
-that don't currently have SDF qualities defined (namely, `titles` and
-`descriptions` members used for internationalization).
-
-A second Supplement is more experimental in that it captures
-information that is actually instance-specific,
-in this case a `forms` member that binds the `status` property to an
-instance-specific CoAP resource.
-[^td-note]
-
-The form really should be part of the class level; defining the entire
-form instead of just the link in the instance information is a
-symptom of not yet getting the class/instance boundary right.
-
-[^td-note]: \\
-    Namespaces are all wrong in this example.
-
-* The input: WoT Thing Model
-
-~~~ json
-{
-    "@context": "https://www.w3.org/2022/wot/td/v1.1",
-    "@type" : "tm:ThingModel",
-    "title": "Lamp Thing Model",
-    "titles": {
-      "en": "Lamp Thing Model",
-      "de": "Thing Model für eine Lampe"
-    },
-    "properties": {
-        "status": {
-            "description": "Current status of the lamp",
-            "descriptions": {
-              "en": "Current status of the lamp",
-              "de": "Aktueller Status der Lampe"
-            },
-            "type": "string",
-            "readOnly": true,
-            "forms": [
-              {
-                "href": "coap://example.org/status"
-              }
-            ]
-        }
-    }
-}
-~~~
-{: #code-wot-input title="Input: WoT Thing Model"}
-
-* The output: SDF model
-
-~~~ sdf
-info:
-  title: Lamp Thing Model
-namespace:
-  wot: http://www.w3.org/ns/td
-defaultNamespace: wot
-sdfObject:
-  LampThingModel:
-    label: Lamp Thing Model
-    sdfProperty:
-      status:
-        description: Current status of the lamp
-        writable: false
-        type: string
-~~~
-{: #code-wot-output1 check="json" pre="yaml2json" title="Output 1: SDF Model"}
-
-* The other output: SDF Supplement for class information
-
-~~~ sdf
-info:
-  title: 'Lamp Thing Model: WoT TM mapping'
-namespace:
-  wot: http://www.w3.org/ns/td
-defaultNamespace: wot
-amend:
-  - "#/sdfObject/LampThingModel":
-      titles:
-        en: Lamp Thing Model
-        de: Thing Model für eine Lampe
-  - "#/sdfObject/LampThingModel/sdfProperty/status":
-      descriptions:
-        en: Current status of the lamp
-        de: Aktueller Status der Lampe
-~~~
-{: #code-wot-output2 check="json" pre="yaml2json" title="Output 2: SDF Supplement"}
-
-* A third output: SDF Supplement for Protocol Bindings
-
-~~~ sdf
-info:
-  title: 'Lamp Thing Model: WoT TM Protocol Binding'
-namespace:
-  wot: http://www.w3.org/ns/td
-defaultNamespace: wot
-amend:
-  - "#/sdfObject/LampThingModel/sdfProperty/status":
-      descriptions:
-      - href: coap://example.org/status
-~~~
-{: #code-wot-output3 check="json" pre="yaml2json" title="Output 3: SDF Supplement for Protocol Bindings"}
-
-
 # Formal Syntax of SDF Supplements {#syntax}
 
 An SDF Supplement has three optional components that are taken
@@ -416,6 +273,154 @@ info:
     (An array in the info block that receives additions from a mapping
     file using the "`‑`" pointer syntax may be a good receptacle for
     receiving information about multiple augmentations.)
+
+# Ecosystem-specific Examples
+
+In the following, we will outline a number of examples that illustrate how
+Supplements can be used to enrich a given SDF model with ecosystem-specific
+information.
+
+## Example Model 1 (ecosystem: IPSO/OMA) {#example1}
+
+An example for an SDF Supplement is given in {{code-example1}}.
+This Supplement is meant to attach to an SDF specification published
+by OneDM, and to add qualities relevant to the IPSO/OMA ecosystem.
+[^namespace-note]
+
+[^namespace-note]: \\
+    Note that this example uses namespaces to identify elements of the
+    referenced specification(s), but has un-namespaced quality names.
+    These two kinds of namespaces are unrelated in SDF, and a more
+    robust example may need to make use of Quality Name Prefixes
+    as defined in {{Section 2.3.3-3 of -sdf}} (independent of a potential
+    feature to add namespace references to definitions that are not
+    intended to go into the default namespace — these are SDF
+    definition namespaces and not quality namespaces, which are one
+    meta-level higher).
+
+* Start of a Supplement for certain OneDM playground models:
+
+~~~ sdf
+info:
+  title: IPSO ID mapping
+namespace:
+  onedm: https://onedm.org/models
+defaultNamespace: onedm
+amend:
+  - "#/sdfObject/Digital_Input":
+      id: 3200
+  - "#/sdfObject/Digital_Input/sdfProperty/Digital_Input_State":
+      id: 5500
+  - "#/sdfObject/Digital_Input/sdfProperty/Digital_Input_Counter":
+      id: 5501
+~~~
+{: #code-example1 check="json" pre="yaml2json" title="A simple example of an SDF Supplement"}
+
+## Example Model 2 (ecosystem: W3C WoT) {#example2}
+
+This example shows a translation of a hypothetical W3C WoT Thing Model
+(as defined in Section 10 of {{-wot-td}})
+into an SDF model plus a Supplement to catch Thing Model attributes
+that don't currently have SDF qualities defined (namely, `titles` and
+`descriptions` members used for internationalization).
+
+A second Supplement is more experimental in that it captures
+information that is actually instance-specific,
+in this case a `forms` member that binds the `status` property to an
+instance-specific CoAP resource.
+[^td-note]
+
+The form really should be part of the class level; defining the entire
+form instead of just the link in the instance information is a
+symptom of not yet getting the class/instance boundary right.
+
+[^td-note]: \\
+    Namespaces are all wrong in this example.
+
+* The input: WoT Thing Model
+
+~~~ json
+{
+    "@context": "https://www.w3.org/2022/wot/td/v1.1",
+    "@type" : "tm:ThingModel",
+    "title": "Lamp Thing Model",
+    "titles": {
+      "en": "Lamp Thing Model",
+      "de": "Thing Model für eine Lampe"
+    },
+    "properties": {
+        "status": {
+            "description": "Current status of the lamp",
+            "descriptions": {
+              "en": "Current status of the lamp",
+              "de": "Aktueller Status der Lampe"
+            },
+            "type": "string",
+            "readOnly": true,
+            "forms": [
+              {
+                "href": "coap://example.org/status"
+              }
+            ]
+        }
+    }
+}
+~~~
+{: #code-wot-input title="Input: WoT Thing Model"}
+
+* The output: SDF model
+
+~~~ sdf
+info:
+  title: Lamp Thing Model
+namespace:
+  wot: http://www.w3.org/ns/td
+defaultNamespace: wot
+sdfObject:
+  LampThingModel:
+    label: Lamp Thing Model
+    sdfProperty:
+      status:
+        description: Current status of the lamp
+        writable: false
+        type: string
+~~~
+{: #code-wot-output1 check="json" pre="yaml2json" title="Output 1: SDF Model"}
+
+* The other output: SDF Supplement for class information
+
+~~~ sdf
+info:
+  title: 'Lamp Thing Model: WoT TM mapping'
+namespace:
+  wot: http://www.w3.org/ns/td
+defaultNamespace: wot
+amend:
+  - "#/sdfObject/LampThingModel":
+      titles:
+        en: Lamp Thing Model
+        de: Thing Model für eine Lampe
+  - "#/sdfObject/LampThingModel/sdfProperty/status":
+      descriptions:
+        en: Current status of the lamp
+        de: Aktueller Status der Lampe
+~~~
+{: #code-wot-output2 check="json" pre="yaml2json" title="Output 2: SDF Supplement"}
+
+* A third output: SDF Supplement for Protocol Bindings
+
+~~~ sdf
+info:
+  title: 'Lamp Thing Model: WoT TM Protocol Binding'
+namespace:
+  wot: http://www.w3.org/ns/td
+defaultNamespace: wot
+amend:
+  - "#/sdfObject/LampThingModel/sdfProperty/status":
+      descriptions:
+      - href: coap://example.org/status
+~~~
+{: #code-wot-output3 check="json" pre="yaml2json" title="Output 3: SDF Supplement for Protocol Bindings"}
 
 IANA Considerations {#iana}
 ===================

--- a/lists.md
+++ b/lists.md
@@ -3,6 +3,12 @@
 {:unnumbered}
 
 {:compact hangindent="11"}
+{{code-augmented-sdf-model}}:
+: {{<<code-augmented-sdf-model}}
+
+{{augmentation-log}}:
+: {{<<augmentation-log}}
+
 {{code-example1}}:
 : {{<<code-example1}}
 
@@ -21,14 +27,20 @@
 {{mapping-cddl}}:
 : {{<<mapping-cddl}}
 
-{{code-augmented-sdf-model}}:
-: {{<<code-augmented-sdf-model}}
-
 
 # List of Tables
 {:unnumbered}
 
 {:compact hangindent="11"}
+{{infoblockqual}}:
+: {{<<infoblockqual}}
+
+{{nssec}}:
+: {{<<nssec}}
+
+{{amendssec}}:
+: {{<<amendssec}}
+
 {{new-media-types}}:
 : {{<<new-media-types}}
 


### PR DESCRIPTION
This PR starts consolidating the specification a bit by reshuffling its structure (moving the examples and the CDDL further to the back) and introducing a new section that defines the data model of Supplements.